### PR TITLE
Docs: Update API to use imageFileName instead of imageUrl

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,28 +1,38 @@
 # Pet Adoption App
 
 ## Description:
+
 Zoodopt is a web-based pet adoption platform designed to connect animal shelters with individuals looking to adopt. It enables shelters to list adoptable pets, and allows users to browse pet profiles and submit adoption applications. The system aims to streamline the pet adoption process by offering a centralized, user-friendly interface for both shelters and the public.
 
 ## Key Features:
 
 ### For Public Users:
+
 - Browse all adoptable pets across registered shelters.
 - View detailed pet profiles including images, age, and breed.
 - Submit adoption applications for individual pets.
 
 ### For Shelter:
+
 - Post and manage their own adoptable pets.
 - View and manage adoption applications submitted for their pets.
 
 ## Resources / Data Models:
+
 - Users
 - Shelters
 - Pets
+
+  - Includes fields: name, type, ageGroup, description, imageFileName, shelterId
+
 - Applications
 
 ## Technology Stack:
-### Frontend: React.js
-### Backend: ASP.NET Core + Entity Framework Core
-### Database: PostgreSQL
-### Languages: JavaScript and C#
 
+### Frontend: React.js
+
+### Backend: ASP.NET Core + Entity Framework Core
+
+### Database: PostgreSQL
+
+### Languages: JavaScript and C#

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -48,7 +48,14 @@
 - Description: Add a new pet listing (shelter staff only)
 - Auth Required: Yes
 - Request Body:
-  - `name`, `type`, `ageGroup`, `description`, `imageUrl`, `shelterId`
+  - `name`: string
+  - `type`: string
+  - `ageGroup`: string
+  - `description`: string
+  - `imageFileName`: string — name of uploaded image file (e.g., `fluffy01.jpg`)
+  - `shelterId`: integer
+
+> 📝 **Note**: The `imageFileName` is not a full URL. Construct full image path as `/images/{imageFileName}`.
 
 ---
 

--- a/docs/openapi-draft.yaml
+++ b/docs/openapi-draft.yaml
@@ -58,6 +58,12 @@ paths:
       responses:
         "200":
           description: List of pets
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/Pet"
 
     post:
       summary: Create a new pet listing (shelter staff only)
@@ -157,7 +163,7 @@ components:
         - type
         - ageGroup
         - description
-        - imageUrl
+        - imageFileName
       properties:
         name:
           type: string
@@ -167,8 +173,28 @@ components:
           type: string
         description:
           type: string
-        imageUrl:
+        imageFileName:
           type: string
+          description: Name of the uploaded image file (e.g., "bella.jpg"). Combine with /images/{imageFileName} to access.
+        shelterId:
+          type: integer
+
+    Pet:
+      type: object
+      properties:
+        id:
+          type: integer
+        name:
+          type: string
+        type:
+          type: string
+        ageGroup:
+          type: string
+        description:
+          type: string
+        imageFileName:
+          type: string
+          description: Name of the stored image file (e.g., "bella.jpg"). Combine with /images/{imageFileName} to access.
         shelterId:
           type: integer
 


### PR DESCRIPTION
This PR updates all documentation to reflect the change from using `imageUrl` to `imageFileName` in the Pet model and API. It also adds a new response schema for pet retrieval.

### Files Changed

- `api-reference.md`: Updated `/pets POST` request body to use `imageFileName`
- `README.md`: Clarified pet resource fields in the data models section
- `openapi-draft.yaml`: 
  - Updated `PetCreate` schema
  - Added full `Pet` schema
  - Modified `GET /pets` to return array of `Pet` objects

### Notes

- `imageFileName` contains only the filename (e.g., `"bella.jpg"`).
- Frontend should construct full image paths as `/images/{imageFileName}`.
