### PR TITLE
Add runtime seeding, appsettings template, and local setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,27 +12,63 @@ Zoodopt is a web-based pet adoption platform designed to connect animal shelters
 - View detailed pet profiles including images, age, and breed.
 - Submit adoption applications for individual pets.
 
-### For Shelter:
+### For Shelter Staff:
 
 - Post and manage their own adoptable pets.
 - View and manage adoption applications submitted for their pets.
 
 ## Resources / Data Models:
 
-- Users
-- Shelters
-- Pets
-
-  - Includes fields: name, type, ageGroup, description, imageFileName, shelterId
-
-- Applications
+- **Users**
+- **Shelters**
+- **Pets**
+  - Includes fields: `name`, `type`, `ageGroup`, `description`, `imageFileName`, `shelterId`
+- **Applications**
 
 ## Technology Stack:
 
-### Frontend: React.js
+- **Frontend:** React.js
+- **Backend:** ASP.NET Core + Entity Framework Core
+- **Database:** PostgreSQL
+- **Languages:** JavaScript and C#
 
-### Backend: ASP.NET Core + Entity Framework Core
+## 🔧 Local Configuration
 
-### Database: PostgreSQL
+To run the backend locally, you need to create a development configuration file.
 
-### Languages: JavaScript and C#
+### 1. Copy the Template
+
+Rename the following file **in the `main` branch before branching** to ensure it exists across all future branches:
+
+```
+appsettings.Development.template.json → appsettings.Development.json
+```
+
+⚠️ If you create the file **after** branching, you’ll have to recreate it manually in each new branch.
+
+### 2. Update Your Database Connection
+
+Edit the new file and fill in your actual PostgreSQL credentials:
+
+```json
+{
+  "ConnectionStrings": {
+    "DefaultConnection": "Host=localhost;Port=5432;Database=zoodopt;Username=your_db_username;Password=your_db_password"
+  }
+}
+```
+
+> ❗ `appsettings.Development.json` is ignored by Git and must be created manually by each developer.
+
+### 3. Run the Backend
+
+```bash
+dotnet build
+dotnet run
+```
+
+Swagger UI will be available at:
+
+```
+http://localhost:5217/swagger
+```

--- a/backend/Data/DbInitializer.cs
+++ b/backend/Data/DbInitializer.cs
@@ -1,0 +1,72 @@
+using backend.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace backend.Data;
+
+public static class DbInitializer
+{
+    public static async Task SeedAsync(ApplicationDbContext context)
+    {
+        await context.Database.MigrateAsync();
+
+        if (!context.Users.Any())
+        {
+            // Create shelter
+            var shelter = new Shelter
+            {
+                Name = "Happy Tails Shelter",
+                Location = "123 Main Street"
+            };
+            context.Shelters.Add(shelter);
+            await context.SaveChangesAsync();
+
+            // Create shelter staff user
+            var shelterUser = new User
+            {
+                Email = "shelter@example.com",
+                PasswordHash = "Password123!", // NOTE: no hashing in this version
+                Role = "ShelterStaff",
+                ShelterId = shelter.Id
+            };
+
+            // Create public user
+            var publicUser = new User
+            {
+                Email = "user@example.com",
+                PasswordHash = "Password123!", // NOTE: again, no hashing
+                Role = "Public"
+            };
+
+            context.Users.AddRange(shelterUser, publicUser);
+            await context.SaveChangesAsync();
+
+            // Create pets under shelter
+            var pets = new List<Pet>
+            {
+                new Pet
+                {
+                    Name = "Max",
+                    Type = "Dog",
+                    AgeGroup = "Adult",
+                    Description = "Friendly Labrador",
+                    ImageFileName = "max.jpg",
+                    ShelterId = shelter.Id,
+                    Shelter = shelter
+                },
+                new Pet
+                {
+                    Name = "Whiskers",
+                    Type = "Cat",
+                    AgeGroup = "Kitten",
+                    Description = "Playful tabby kitten",
+                    ImageFileName = "whiskers.jpg",
+                    ShelterId = shelter.Id,
+                    Shelter = shelter
+                }
+            };
+
+            context.Pets.AddRange(pets);
+            await context.SaveChangesAsync();
+        }
+    }
+}

--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -39,4 +39,11 @@ app.UseHttpsRedirection();
 app.UseAuthorization();
 
 app.MapControllers();
-app.Run();
+
+using (var scope = app.Services.CreateScope())
+{
+    var context = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+    await DbInitializer.SeedAsync(context);
+}
+
+await app.RunAsync();

--- a/backend/appsettings.Development.template.json
+++ b/backend/appsettings.Development.template.json
@@ -1,0 +1,5 @@
+{
+  "ConnectionStrings": {
+    "DefaultConnection": "Host=localhost;Port=5432;Database=zoodopt;Username=your_db_username;Password=your_db_password"
+  }
+}


### PR DESCRIPTION
### Summary
This PR finalizes the backend seed logic and adds clear instructions for local configuration.

### Changes Included
- `DbInitializer.cs`: seeds roles, users, shelter, and pets at startup
- `Program.cs`: calls the seeding method before app run
- `appsettings.Development.template.json`: added as a template for local config
- `README.md`: added a section explaining how to set up the config file and run the backend

### Notes
- `appsettings.Development.json` is excluded from Git. All devs must create it manually by copying the template.
- Database name is `zoodopt`. Default test users:
  - `shelter@example.com` / `Password123!`
  - `user@example.com` / `Password123!`
