### PR TITLE
Add GET /applications/my-applications Endpoint

### DIFF
--- a/backend/Controllers/ApplicationsController.cs
+++ b/backend/Controllers/ApplicationsController.cs
@@ -56,6 +56,24 @@ public class ApplicationsController : BaseController
         return Ok(apps.Select(ToDto));
     }
 
+    // GET /applications/my-applications
+    [Authorize]
+    [HttpGet("my-applications")]
+    public async Task<IActionResult> GetMyApplications()
+    {
+        var user = await GetCurrentUserAsync();
+        if (user == null)
+            return StandardError(401, "User not authenticated.");
+
+        var apps = await _context.Applications
+            .Include(a => a.Pet)
+            .Where(a => a.UserId == user.Id)
+            .OrderByDescending(a => a.SubmittedAt)
+            .ToListAsync();
+
+        return Ok(apps.Select(ToDto));
+    }
+
     // GET /applications/{id}
     [Authorize]
     [HttpGet("{id}")]

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -2,28 +2,29 @@
 
 ### API Endpoint Table
 
-| Endpoint                   | Method | Auth | Purpose                                    |
-| -------------------------- | ------ | ---- | ------------------------------------------ |
-| /auth/register             | POST   | No   | Register a user (public/staff/admin)       |
-| /auth/login                | POST   | No   | Authenticate and get token                 |
-| /auth/logout               | POST   | No   | "Logout" (client removes token)            |
-| /users/me                  | GET    | Yes  | Get current user's profile                 |
-| /pets                      | GET    | No   | List all pets (with filters)               |
-| /pets/{id}                 | GET    | No   | Get specific pet details                   |
-| /pets                      | POST   | Yes  | Add new pet (shelter staff/admin)          |
-| /pets/{id}                 | PUT    | Yes  | Update pet (shelter staff/admin)           |
-| /pets/{id}                 | DELETE | Yes  | Delete pet (shelter staff/admin)           |
-| /applications              | GET    | Yes  | View apps for shelter's pets (staff/admin) |
-| /applications/{id}         | GET    | Yes  | Get specific application details           |
-| /applications              | POST   | Yes  | Submit adoption app (any authenticated)    |
-| /applications/{id}/message | PUT    | Yes  | Update application message (applicant)     |
-| /applications/{id}/status  | PUT    | Yes  | Update app status (staff/admin)            |
-| /applications/{id}         | DELETE | Yes  | Delete application (applicant/admin)       |
-| /shelters                  | GET    | No   | List all shelters (public)                 |
-| /shelters/{id}             | GET    | No   | Get specific shelter details               |
-| /shelters                  | POST   | Yes  | Create shelter (admin only)                |
-| /shelters/{id}             | PUT    | Yes  | Update shelter (admin only)                |
-| /shelters/{id}             | DELETE | Yes  | Delete shelter (admin only)                |
+| Endpoint                      | Method | Auth | Purpose                                    |
+| ----------------------------- | ------ | ---- | ------------------------------------------ |
+| /auth/register                | POST   | No   | Register a user (public/staff/admin)       |
+| /auth/login                   | POST   | No   | Authenticate and get token                 |
+| /auth/logout                  | POST   | No   | "Logout" (client removes token)            |
+| /users/me                     | GET    | Yes  | Get current user's profile                 |
+| /pets                         | GET    | No   | List all pets (with filters)               |
+| /pets/{id}                    | GET    | No   | Get specific pet details                   |
+| /pets                         | POST   | Yes  | Add new pet (shelter staff/admin)          |
+| /pets/{id}                    | PUT    | Yes  | Update pet (shelter staff/admin)           |
+| /pets/{id}                    | DELETE | Yes  | Delete pet (shelter staff/admin)           |
+| /applications                 | GET    | Yes  | View apps for shelter's pets (staff/admin) |
+| /applications/my-applications | GET    | Yes  | Get current user's own applications        |
+| /applications/{id}            | GET    | Yes  | Get specific application details           |
+| /applications                 | POST   | Yes  | Submit adoption app (any authenticated)    |
+| /applications/{id}/message    | PUT    | Yes  | Update application message (applicant)     |
+| /applications/{id}/status     | PUT    | Yes  | Update app status (staff/admin)            |
+| /applications/{id}            | DELETE | Yes  | Delete application (applicant/admin)       |
+| /shelters                     | GET    | No   | List all shelters (public)                 |
+| /shelters/{id}                | GET    | No   | Get specific shelter details               |
+| /shelters                     | POST   | Yes  | Create shelter (admin only)                |
+| /shelters/{id}                | PUT    | Yes  | Update shelter (admin only)                |
+| /shelters/{id}                | DELETE | Yes  | Delete shelter (admin only)                |
 
 ## Authentication
 
@@ -177,7 +178,7 @@ Common HTTP status codes:
   description: "Updated description" (optional)
   imageFile: [image file] (optional - replaces existing image)
   ```
-- **Note**: 
+- **Note**:
   - Shelter staff can only update pets from their own shelter
   - If a new image is uploaded, the old image is automatically deleted
   - Images are validated for type and size (max 5MB)
@@ -200,6 +201,37 @@ Common HTTP status codes:
 - **Description**: View applications for pets (shelter staff and admin only)
 - **Auth Required**: Yes (ShelterStaff or Admin)
 - **Response**: Array of applications (shelter staff see only their shelter's applications)
+
+---
+
+#### `/applications/my-applications` — `GET`
+
+- **Description**: Get all applications submitted by the current user
+- **Auth Required**: Yes (any authenticated user)
+- **Response**: Array of the user's own applications, ordered by submission date (newest first)
+- **Example Response**:
+  ```json
+  [
+    {
+      "id": 4,
+      "petId": 2,
+      "userId": 2,
+      "message": "I'm an experienced adopter.",
+      "status": "Pending",
+      "submittedAt": "2025-07-31T17:09:04.000Z",
+      "petName": "Whiskers"
+    },
+    {
+      "id": 1,
+      "petId": 1,
+      "userId": 2,
+      "message": "I love dogs and have experience adopting.",
+      "status": "Approved",
+      "submittedAt": "2025-07-31T05:02:37.000Z",
+      "petName": "Max"
+    }
+  ]
+  ```
 
 ---
 

--- a/docs/openapi-draft.yaml
+++ b/docs/openapi-draft.yaml
@@ -650,6 +650,45 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
 
+  /applications/my-applications:
+    get:
+      tags:
+        - Applications
+      summary: Get current user's applications
+      description: Get all applications submitted by the current authenticated user, ordered by submission date (newest first)
+      security:
+        - bearerAuth: []
+      responses:
+        "200":
+          description: List of user's applications
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/ApplicationResponseDto"
+              example:
+                - id: 4
+                  petId: 2
+                  userId: 2
+                  message: "I'm an experienced adopter."
+                  status: "Pending"
+                  submittedAt: "2025-07-31T17:09:04.000Z"
+                  petName: "Whiskers"
+                - id: 1
+                  petId: 1
+                  userId: 2
+                  message: "I love dogs and have experience adopting."
+                  status: "Approved"
+                  submittedAt: "2025-07-31T05:02:37.000Z"
+                  petName: "Max"
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+
   /applications/{id}:
     get:
       tags:


### PR DESCRIPTION
## 📋 Summary

This PR adds a new API endpoint that allows authenticated users to fetch their own adoption applications, providing users with visibility into their application history and status.

## 🚀 Changes Made

### Backend Implementation
- **New Endpoint**: `GET /applications/my-applications`
- **Controller**: Updated `ApplicationsController.cs` with new `GetMyApplications()` method
- **Authentication**: Requires valid JWT token (any authenticated user role)
- **Data Filtering**: Returns only applications belonging to the current user
- **Ordering**: Results sorted by submission date (newest first)
- **Includes**: Pet information included via Entity Framework Include statement

### Documentation Updates
- **API Reference**: Updated `docs/api-reference.md` with endpoint details and example responses
- **OpenAPI Spec**: Updated `docs/openapi-draft.yaml` with complete schema and response examples

## 🔧 Technical Details

### Endpoint Specification
```
GET /applications/my-applications
Authorization: Bearer <jwt-token>
```

### Response Format
```json
[
  {
    "id": 4,
    "petId": 2,
    "userId": 2,
    "message": "I'm an experienced adopter.",
    "status": "Pending",
    "submittedAt": "2025-07-31T17:09:04.000Z",
    "petName": "Whiskers"
  }
]
```

### Security Features
- ✅ **Authentication Required**: Bearer token validation
- ✅ **User Isolation**: Only shows applications for the authenticated user
- ✅ **No Role Restrictions**: Available to Public, ShelterStaff, and Admin users
- ✅ **Data Privacy**: Users cannot access other users' applications

## 🧪 Testing

### Test Results
- ✅ **Authentication**: Returns 401 when no token provided
- ✅ **User Filtering**: Only returns current user's applications
- ✅ **Data Structure**: Includes pet names and all application fields
- ✅ **Ordering**: Results ordered by submission date (newest first)
- ✅ **Empty Results**: Returns empty array when user has no applications

---

**Branch**: `feature/add-my-applications-endpoint`  
**Commit**: `2cf7814` - Add GET /applications/my-applications endpoint for user's own applications  
**Tested**: ✅ Backend API tested with multiple user scenarios  
**Documentation**: ✅ Both API reference and OpenAPI spec updated
