### PR TITLE
fix: delay fetch until AuthContext loads to prevent 401 on reload

### DIFF
--- a/frontend/context/AuthContext.jsx
+++ b/frontend/context/AuthContext.jsx
@@ -5,6 +5,7 @@ const AuthContext = createContext();
 export const AuthProvider = ({ children }) => {
   const [token, setToken] = useState(null);
   const [role, setRole] = useState(null);
+  const [loadingAuth, setLoadingAuth] = useState(true);
 
   useEffect(() => {
     const storedToken = localStorage.getItem('token') || sessionStorage.getItem('token');
@@ -13,6 +14,7 @@ export const AuthProvider = ({ children }) => {
       setToken(storedToken);
       setRole(storedRole);
     }
+    setLoadingAuth(false);
   }, []);
 
   const login = (newToken, newRole, rememberMe) => {
@@ -31,7 +33,7 @@ export const AuthProvider = ({ children }) => {
   };
 
   return (
-    <AuthContext.Provider value={{ token, role, login, logout }}>
+    <AuthContext.Provider value={{ token, role, login, logout, loadingAuth }}>
       {children}
     </AuthContext.Provider>
   );

--- a/frontend/src/pages/Pets/MyApplicationsPage.jsx
+++ b/frontend/src/pages/Pets/MyApplicationsPage.jsx
@@ -4,7 +4,7 @@ import { useNavigate } from 'react-router-dom';
 import './MyApplicationsPage.css';
 
 const MyApplicationsPage = () => {
-  const { token } = useAuth();
+  const { token, loadingAuth } = useAuth();
   const [applications, setApplications] = useState([]);
   const [editingId, setEditingId] = useState(null);
   const [editedMessage, setEditedMessage] = useState('');
@@ -16,15 +16,18 @@ const MyApplicationsPage = () => {
   const navigate = useNavigate();
 
   useEffect(() => {
+    if (loadingAuth || !token) return;
+
     const fetchApplications = async () => {
       try {
         const res = await fetch('http://localhost:5217/applications/my-applications', {
           headers: { Authorization: `Bearer ${token}` },
         });
-        
+
         if (!res.ok) {
           throw new Error(`Failed to load applications: ${res.status} response`);
         }
+
         const apps = await res.json();
 
         const enrichedApps = await Promise.all(
@@ -59,7 +62,7 @@ const MyApplicationsPage = () => {
     };
 
     fetchApplications();
-  }, [token]);
+  }, [token, loadingAuth]);
 
   const handleEditClick = (app) => {
     setEditingId(app.id);
@@ -156,7 +159,17 @@ const MyApplicationsPage = () => {
       </div>
     );
   }
-
+  if (loadingAuth) {
+    return (
+      <div className="full-page-wrapper bg-gradient-primary">
+        <div className="status-box fade-in">
+          <div className="spinner">⏳</div>
+          <h3 className="status-text">Initializing session...</h3>
+        </div>
+      </div>
+    );
+  }
+  
   return (
     <div className="my-applications-page">
       <div className="container py-5">


### PR DESCRIPTION
- Added loadingAuth state in AuthContext to track initialization
- Updated AuthProvider to set token and role from storage and set loadingAuth to false after
- Exposed loadingAuth through context
- Updated MyApplicationsPage to wait for loadingAuth before triggering fetch
- Added loading spinner while auth is initializing
- Prevents 401 errors when refreshing or directly accessing /pets/my-applications